### PR TITLE
perf: perf miot entity init logic

### DIFF
--- a/custom_components/xiaomi_home/button.py
+++ b/custom_components/xiaomi_home/button.py
@@ -85,4 +85,4 @@ class Button(MIoTActionEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        return await self.action_async()
+        await self.action_async()

--- a/custom_components/xiaomi_home/climate.py
+++ b/custom_components/xiaomi_home/climate.py
@@ -44,6 +44,12 @@ or other intellectual property rights of Xiaomi or its affiliates; or,
 off Xiaomi or its affiliates' products.
 
 Climate entities for Xiaomi Home.
+- air-conditioner
+- air-condition-outlet
+- bath-heater
+- electric-blanket
+- heater
+- thermostat
 """
 from __future__ import annotations
 import logging

--- a/custom_components/xiaomi_home/cover.py
+++ b/custom_components/xiaomi_home/cover.py
@@ -44,6 +44,10 @@ or other intellectual property rights of Xiaomi or its affiliates; or,
 off Xiaomi or its affiliates' products.
 
 Cover entities for Xiaomi Home.
+- airer
+- curtain
+- window-opener
+- motor-controller
 """
 from __future__ import annotations
 import logging

--- a/custom_components/xiaomi_home/event.py
+++ b/custom_components/xiaomi_home/event.py
@@ -46,7 +46,7 @@ off Xiaomi or its affiliates' products.
 Event entities for Xiaomi Home.
 """
 from __future__ import annotations
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -86,7 +86,7 @@ class Event(MIoTEventEntity, EventEntity):
         self._attr_device_class = spec.device_class
 
     def on_event_occurred(
-        self, name: str, arguments: dict[str, Any] | None = None
+        self, name: str, arguments: Optional[dict[str, Any]] = None
     ) -> None:
         """An event is occurred."""
         self._trigger_event(event_type=name, event_attributes=arguments)

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -1158,7 +1158,7 @@ class MIoTServiceEntity(Entity):
         if self._pending_write_ha_state_timer:
             self._pending_write_ha_state_timer.cancel()
         self._pending_write_ha_state_timer = self._main_loop.call_later(
-            1, self.__write_ha_state_handler)
+            30, self.__write_ha_state_handler)
 
     def __write_ha_state_handler(self) -> None:
         self._pending_write_ha_state_timer = None
@@ -1321,7 +1321,7 @@ class MIoTPropertyEntity(Entity):
         if self._pending_write_ha_state_timer:
             self._pending_write_ha_state_timer.cancel()
         self._pending_write_ha_state_timer = self._main_loop.call_later(
-            1, self.__write_ha_state_handler)
+            30, self.__write_ha_state_handler)
 
     def __write_ha_state_handler(self) -> None:
         self._pending_write_ha_state_timer = None

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -1398,7 +1398,7 @@ class MIoTEventEntity(Entity):
 
     @abstractmethod
     def on_event_occurred(
-        self, name: str, arguments: dict[str, Any] | None = None
+        self, name: str, arguments: Optional[dict[str, Any]] = None
     ) -> None: ...
 
     def __on_event_occurred(self, params: dict, ctx: Any) -> None:

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -991,6 +991,15 @@ class MIoTServiceEntity(Entity):
                 self.miot_device.unsub_event(
                     siid=event.service.iid, eiid=event.iid, sub_id=sub_id)
 
+    async def async_update(self) -> None:
+        for prop in self.entity_data.props:
+            if not prop.readable:
+                continue
+            self._prop_value_map[prop] = await self.get_property_async(prop)
+            _LOGGER.info(
+                'async_update, %s, %s, %s', self.entity_id, prop.name,
+                self._prop_value_map[prop])
+
     def get_map_value(
         self, map_: Optional[dict[int, Any]], key: int
     ) -> Any:
@@ -1235,6 +1244,13 @@ class MIoTPropertyEntity(Entity):
         self.miot_device.unsub_property(
             siid=self.service.iid, piid=self.spec.iid,
             sub_id=self._value_sub_id)
+
+    async def async_update(self) -> None:
+        if not self.spec.readable:
+            return
+        self._value = await self.get_property_async()
+        _LOGGER.info(
+            'async_update, %s, %s, %s', self.entity_id, self.name, self._value)
 
     def get_vlist_description(self, value: Any) -> Optional[str]:
         if not self._value_list:

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -1339,7 +1339,7 @@ class MIoTEventEntity(Entity):
     _main_loop: asyncio.AbstractEventLoop
     _attr_event_types: list[str]
     _arguments_map: dict[int, str]
-    _state_sub_id: int
+    # _state_sub_id: int
     _value_sub_id: int
 
     def __init__(self, miot_device: MIoTDevice, spec: MIoTSpecEvent) -> None:
@@ -1360,13 +1360,13 @@ class MIoTEventEntity(Entity):
         self._attr_name = (
             f'{"* "if self.spec.proprietary else " "}'
             f'{self.service.description_trans} {spec.description_trans}')
-        self._attr_available = miot_device.online
+        self._attr_available = True  # miot_device.online
         self._attr_event_types = [spec.description_trans]
 
         self._arguments_map = {}
         for prop in spec.argument:
             self._arguments_map[prop.iid] = prop.description_trans
-        self._state_sub_id = 0
+        # self._state_sub_id = 0
         self._value_sub_id = 0
 
         _LOGGER.info(
@@ -1380,18 +1380,18 @@ class MIoTEventEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         # Sub device state changed
-        self._state_sub_id = self.miot_device.sub_device_state(
-            key=f'event.{ self.service.iid}.{self.spec.iid}',
-            handler=self.__on_device_state_changed)
+        # self._state_sub_id = self.miot_device.sub_device_state(
+        #     key=f'event.{ self.service.iid}.{self.spec.iid}',
+        #     handler=self.__on_device_state_changed)
         # Sub value changed
         self._value_sub_id = self.miot_device.sub_event(
             handler=self.__on_event_occurred,
             siid=self.service.iid, eiid=self.spec.iid)
 
     async def async_will_remove_from_hass(self) -> None:
-        self.miot_device.unsub_device_state(
-            key=f'event.{ self.service.iid}.{self.spec.iid}',
-            sub_id=self._state_sub_id)
+        # self.miot_device.unsub_device_state(
+        #     key=f'event.{ self.service.iid}.{self.spec.iid}',
+        #     sub_id=self._state_sub_id)
         self.miot_device.unsub_event(
             siid=self.service.iid, eiid=self.spec.iid,
             sub_id=self._value_sub_id)
@@ -1429,14 +1429,14 @@ class MIoTEventEntity(Entity):
             name=self.spec.description_trans, arguments=trans_arg)
         self.async_write_ha_state()
 
-    def __on_device_state_changed(
-        self, key: str, state: MIoTDeviceState
-    ) -> None:
-        state_new = state == MIoTDeviceState.ONLINE
-        if state_new == self._attr_available:
-            return
-        self._attr_available = state_new
-        self.async_write_ha_state()
+    # def __on_device_state_changed(
+    #     self, key: str, state: MIoTDeviceState
+    # ) -> None:
+    #     state_new = state == MIoTDeviceState.ONLINE
+    #     if state_new == self._attr_available:
+    #         return
+    #     self._attr_available = state_new
+    #     self.async_write_ha_state()
 
 
 class MIoTActionEntity(Entity):

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -1295,9 +1295,10 @@ class MIoTPropertyEntity(Entity):
             self._pending_write_ha_state_timer.cancel()
             self._pending_write_ha_state_timer = None
         value = self.spec.value_format(params['value'])
+        value = self.spec.eval_expr(src_value=value)
         if self._value == value:
             return
-        self._value = self.spec.eval_expr(value)
+        self._value = value
         self.async_write_ha_state()
 
     def __on_device_state_changed(


### PR DESCRIPTION
### Changed
- Keep event entity always available, avoid the generation of non-existent events when the device changes from available to unavailable.
- Perf entity init logic
- Adjust the entity value refresh timeout to 30 seconds.

### Fixed
- Fix button entity `async_press` return type error.