### PR TITLE
perf: get device info logic

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_cloud.py
+++ b/custom_components/xiaomi_home/miot/miot_cloud.py
@@ -858,8 +858,8 @@ class MIoTHttpClient:
             timeout=10)
         if http_res.status != 200:
             _LOGGER.info(
-                f'get urn by model failed, {http_res.status}, '
-                f'{model}, {version}')
+                'get urn by model failed, %s, %s, %s',
+                http_res.status, model, version)
             return None
         res_obj: Dict = await http_res.json()
         if not isinstance(res_obj, Dict):


### PR DESCRIPTION
### Changed
- When the device has no urn field, it will try to get the urn through the model.